### PR TITLE
add warning message for empty group field when no group exists

### DIFF
--- a/install/tablesets/ynewsletter_tables.json
+++ b/install/tablesets/ynewsletter_tables.json
@@ -274,7 +274,7 @@
                 "default": "",
                 "size": "",
                 "only_empty": "",
-                "message": "",
+                "message": "translate:ynewsletter_msg_pleasecreateagroup",
                 "table": "rex_ynewsletter_group",
                 "hashname": "",
                 "password_hash": "",


### PR DESCRIPTION

![Zwischenablage-2](https://user-images.githubusercontent.com/1277494/96247765-d9ed5a00-0faa-11eb-85cd-b20355846081.jpg)

- passiert nur solange es noch keine Gruppe gibt
- Die Message existiert schon als msg für das validate empty und ist dann auch im be_relation Feld als empty message drin



