### PR TITLE
Ausschlussliste : E-Mail Abgleich angepasst

### DIFF
--- a/lib/ynewsletter_group.php
+++ b/lib/ynewsletter_group.php
@@ -13,7 +13,7 @@ class rex_ynewsletter_group extends \rex_yform_manager_dataset
     {
         $EMails = [];
         foreach (rex_ynewsletter_exclusionlist::getByGroupId($this->getId()) as $Entry) {
-            $EMails[] = $Entry->getValue('email');
+            $EMails[] = mb_strtolower($Entry->getValue('email'));
         }
         return $EMails;
     }
@@ -28,7 +28,7 @@ class rex_ynewsletter_group extends \rex_yform_manager_dataset
         $ExclusionEMails = $this->getExclusionsEMails();
         $Group = $this;
         $Users = array_filter($Users, static function ($User) use ($ExclusionEMails, $Group) {
-            if (in_array($User[$Group->getEMailField()], $ExclusionEMails, true)) {
+            if (in_array(mb_strtolower($User[$Group->getEMailField()]), $ExclusionEMails, true)) {
                 return false;
             }
             return true;


### PR DESCRIPTION
Es wurde durch Zufall herausgefunden, dass die Ausschlussliste für Newsletter nur greift, wenn die E-Mail-Adresse immer gleich geschrieben ist. Es ist also ein Unterschied, ob die E-Mail-Adresse `Vorname.Nachname@...` oder `vorname.nachname@...` eingegeben wird. 

Mit diesem PR wird der Abgleich angepasst, sodass die Schreibweise unerheblich ist. 